### PR TITLE
Logging in millisecs

### DIFF
--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -52,7 +52,7 @@ namespace Neo.Plugins
         {
             if (source != nameof(ConsensusService)) return;
             DateTime now = DateTime.Now;
-            string line = $"[{now.TimeOfDay:hh\\:mm\\:ss}] {message}";
+            string line = $"[{now.TimeOfDay:hh\\:mm\\:ss\\.fff}] {message}";
             Console.WriteLine(line);
             if (string.IsNullOrEmpty(log_dictionary)) return;
             lock (log_dictionary)


### PR DESCRIPTION
After change to Akka consensus in NEO 3.0, it's so fast that seconds do not mean much anymore.. now milliseconds is important to actually know of what is going on the consensus algorithm.