### PR TITLE
remove break statement from FilterFree

### DIFF
--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -44,8 +44,6 @@ namespace Neo.Plugins
                     yield return tx;
                 else if (count++ < Settings.Default.MaxFreeTransactionsPerBlock)
                     yield return tx;
-                else
-                    yield break;
         }
 
         void ILogPlugin.Log(string source, LogLevel level, string message)


### PR DESCRIPTION
In `FilterFree`, once the free transaction limit has been reached, `yield break` is called, preventing further iteration on the the list of transactions. Hence, blocks become limited to contain only the number of transactions that were returned before that point, instead of iterating all the way to `MaxTransactionsPerBlock`. This change removes that statement so that any additional transactions with fees attached may be processed as the `foreach` statement continues.