### PR TITLE
Fix Priority Fee Transactions being treated as Free

### DIFF
--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -32,7 +32,7 @@ namespace Neo.Plugins
             Transaction[] array = transactions.ToArray();
             if (array.Length + 1 <= Settings.Default.MaxTransactionsPerBlock)
                 return array;
-            transactions = array.OrderByDescending(p => p.NetworkFee).Take(Settings.Default.MaxTransactionsPerBlock - 1);
+            transactions = array.OrderByDescending(p => p.NetworkFee / p.Size).ThenByDescending(p => p.NetworkFee).Take(Settings.Default.MaxTransactionsPerBlock - 1);
             return FilterFree(transactions);
         }
 

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -32,7 +32,7 @@ namespace Neo.Plugins
             Transaction[] array = transactions.ToArray();
             if (array.Length + 1 <= Settings.Default.MaxTransactionsPerBlock)
                 return array;
-            transactions = array.OrderByDescending(p => p.NetworkFee / p.Size).Take(Settings.Default.MaxTransactionsPerBlock - 1);
+            transactions = array.OrderByDescending(p => p.NetworkFee).Take(Settings.Default.MaxTransactionsPerBlock - 1);
             return FilterFree(transactions);
         }
 


### PR DESCRIPTION
Currently there is an issue with Integer rounding making **small fee tx behave like free tx.**

Believe this is the cause of priority fee not getting observed.

Simply removing p.Size in the ranking constraint will resolve this. Discussed with jseagrave21.
Based on Belane's investigation.

@erikzhang