### PR TITLE
OnImportMaxHeight Plugin in the scope of simple policy

### DIFF
--- a/SimplePolicy/Settings.cs
+++ b/SimplePolicy/Settings.cs
@@ -11,6 +11,7 @@ namespace Neo.Plugins
     {
         public int MaxTransactionsPerBlock { get; }
         public int MaxFreeTransactionsPerBlock { get; }
+	public uint MaxOnImportHeight { get; }
         public BlockedAccounts BlockedAccounts { get; }
 
         public static Settings Default { get; }
@@ -24,6 +25,7 @@ namespace Neo.Plugins
         {
             this.MaxTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxTransactionsPerBlock"), 500, p => int.Parse(p));
             this.MaxFreeTransactionsPerBlock = GetValueOrDefault(section.GetSection("MaxFreeTransactionsPerBlock"), 20, p => int.Parse(p));
+ 	    this.MaxOnImportHeight = (uint)GetValueOrDefault(section.GetSection("MaxOnImportHeight"), 0, p => int.Parse(p));
             this.BlockedAccounts = new BlockedAccounts(section.GetSection("BlockedAccounts"));
         }
 

--- a/SimplePolicy/SimplePolicy/config.json
+++ b/SimplePolicy/SimplePolicy/config.json
@@ -2,6 +2,7 @@
   "PluginConfiguration": {
     "MaxTransactionsPerBlock": 500,
     "MaxFreeTransactionsPerBlock": 20,
+    "MaxOnImportHeight": 0,
     "BlockedAccounts": {
       "Type": "AllowAll",
       "List": []

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -46,6 +46,13 @@ namespace Neo.Plugins
                     yield return tx;
         }
 
+        public bool CheckMaxOnImportHeight(uint currentImportBlockIndex)
+        {
+	    if(Settings.Default.MaxOnImportHeight != 0 && Settings.Default.MaxOnImportHeight == currentImportBlockIndex)
+		return true;
+	    return false;
+        }
+
         void ILogPlugin.Log(string source, LogLevel level, string message)
         {
             if (source != nameof(ConsensusService)) return;


### PR DESCRIPTION
This would be the impact, @erikzhang.
Everyone would need to update their `config` file because of the parameters load.
What do you think, master?

Should we move it to that isolated plugin, such as that `ILoadingPlugin/IOnImportPlugin`? 