### PR TITLE
Ensure PoW correct order for TXs tiebreakers

### DIFF
--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -67,14 +67,14 @@ namespace Neo.Plugins
                 .OrderByDescending(p => p.NetworkFee / p.Size)
                 .ThenByDescending(p => p.NetworkFee)
                 .ThenByDescending(p => InHighPriorityList(p))
-                .ThenByDescending(p => p.Transaction.Hash)
+                .ThenByAscending(p => p.Transaction.Hash)
                 .Take(Settings.Default.MaxFreeTransactionsPerBlock)
                 .ToArray();
 
             Transaction[] non_free = tx_list.Where(p => !p.IsLowPriority)
                 .OrderByDescending(p => p.NetworkFee / p.Size)
                 .ThenByDescending(p => p.NetworkFee)
-                .ThenByDescending(p => p.Transaction.Hash)
+                .ThenByAscending(p => p.Transaction.Hash)
                 .Take(Settings.Default.MaxTransactionsPerBlock - free.Length - 1)
                 .ToArray();
 

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -67,12 +67,14 @@ namespace Neo.Plugins
                 .OrderByDescending(p => p.NetworkFee / p.Size)
                 .ThenByDescending(p => p.NetworkFee)
                 .ThenByDescending(p => InHighPriorityList(p))
+                .ThenByDescending(p => p.Transaction.Hash)
                 .Take(Settings.Default.MaxFreeTransactionsPerBlock)
                 .ToArray();
 
             Transaction[] non_free = tx_list.Where(p => !p.IsLowPriority)
                 .OrderByDescending(p => p.NetworkFee / p.Size)
                 .ThenByDescending(p => p.NetworkFee)
+                .ThenByDescending(p => p.Transaction.Hash)
                 .Take(Settings.Default.MaxTransactionsPerBlock - free.Length - 1)
                 .ToArray();
 


### PR DESCRIPTION
With this we should ensure the following order (if fee and fee/byte are the same):
[000000,000001, ..., 00000f, ..., ffffff]