### PR TITLE
Commit as the final step of persistence in StatesDumper

### DIFF
--- a/StatesDumper/StatesDumper.cs
+++ b/StatesDumper/StatesDumper.cs
@@ -122,6 +122,12 @@ namespace Neo.Plugins
 
         public void OnCommit(Snapshot snapshot)
         {
+            if (Settings.Default.PersistAction.HasFlag(PersistActions.StorageChanges))
+                OnCommitStorage(snapshot);
+        }
+
+        public void OnCommitStorage(Snapshot snapshot)
+        {
             uint blockIndex = snapshot.Height;
             if (bs_cache.Count > 0)
             {
@@ -136,7 +142,7 @@ namespace Neo.Plugins
                 }
             }
         }
-
+        
         public bool ShouldThrowExceptionFromCommit(Exception ex)
         {
             Console.WriteLine($"Error writing States with StatesDumper.{Environment.NewLine}{ex}");

--- a/StatesDumper/StatesDumper.cs
+++ b/StatesDumper/StatesDumper.cs
@@ -84,10 +84,6 @@ namespace Neo.Plugins
             uint blockIndex = snapshot.Height;
             if (blockIndex >= Settings.Default.HeightToBegin)
             {
-                string dirPath = "./Storage";
-                Directory.CreateDirectory(dirPath);
-                string path = $"{HandlePaths(dirPath, blockIndex)}/dump-block-{blockIndex.ToString()}.json";
-
                 JArray array = new JArray();
 
                 foreach (DataCache<StorageKey, StorageItem>.Trackable trackable in snapshot.Storages.GetChangeSet())
@@ -121,9 +117,20 @@ namespace Neo.Plugins
                 bs_item["size"] = array.Count;
                 bs_item["storage"] = array;
                 bs_cache.Add(bs_item);
+            }
+        }
 
+        public void OnCommit(Snapshot snapshot)
+        {
+            uint blockIndex = snapshot.Height;
+            if (bs_cache.Count > 0)
+            {
                 if ((blockIndex % Settings.Default.BlockCacheSize == 0) || (blockIndex > Settings.Default.HeightToStartRealTimeSyncing))
                 {
+                    string dirPath = "./Storage";
+                    Directory.CreateDirectory(dirPath);
+                    string path = $"{HandlePaths(dirPath, blockIndex)}/dump-block-{blockIndex.ToString()}.json";
+
                     File.WriteAllText(path, bs_cache.ToString());
                     bs_cache.Clear();
                 }

--- a/StatesDumper/StatesDumper.cs
+++ b/StatesDumper/StatesDumper.cs
@@ -137,6 +137,12 @@ namespace Neo.Plugins
             }
         }
 
+        public bool ShouldThrowExceptionFromCommit(Exception ex)
+        {
+            Console.WriteLine($"Error writing States with StatesDumper.{Environment.NewLine}{ex}");
+            return true;
+        }
+
         private static string HandlePaths(string dirPath, uint blockIndex)
         {
             //Default Parameter


### PR DESCRIPTION
Use the new `Commit` method for performing writes. See neo-project/neo#568