### PR TITLE
Import blocks after plugins are loaded.

### DIFF
--- a/ImportBlocks/ImportBlocks.cs
+++ b/ImportBlocks/ImportBlocks.cs
@@ -14,7 +14,7 @@ namespace Neo.Plugins
 {
     public class ImportBlocks : Plugin
     {
-        public ImportBlocks()
+        public override void OnPluginsLoaded()
         {
             OnImport();
         }

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.10.1" />
+    <PackageReference Include="Neo" Version="2.10.1-CI00002" />
   </ItemGroup>
 
 </Project>

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.9.4" />
+    <PackageReference Include="Neo" Version="2.10.1" />
   </ItemGroup>
 
 </Project>

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.9.4</Version>
-    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
+    <Version>2.10.1</Version>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Update="ImportBlocks\config.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
All persist plugins need to be loaded before blocks start importing.

Depends on neo-project/neo/pull/633