### PR TITLE
Check authentication during pre-processing of the rpc request.

### DIFF
--- a/RpcSecurity/RpcSecurity.cs
+++ b/RpcSecurity/RpcSecurity.cs
@@ -16,12 +16,12 @@ namespace Neo.Plugins
 
         public void PreProcess(HttpContext context, string method, JArray _params)
         {
-        }
-        
-        public JObject OnProcess(HttpContext context, string method, JArray _params)
-        {
             if (!CheckAuth(context) || Settings.Default.DisabledMethods.Contains(method))
                 throw new RpcException(-400, "Access denied");
+        }
+
+        public JObject OnProcess(HttpContext context, string method, JArray _params)
+        {
             return null;
         }
 

--- a/RpcSecurity/RpcSecurity.csproj
+++ b/RpcSecurity/RpcSecurity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.9.4</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <RootNamespace>Neo.Plugins</RootNamespace>
   </PropertyGroup>
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="2.9.4" />
+    <PackageReference Include="Neo" Version="2.10.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Order plugins are run could allow another plugin to process something before the `RpcSecurity` plugin throws an exception. This fixes the issue by having `RpcSecurity` throw from `PreProcess`.