### PR TITLE
Make calculation for extra gas on "send*" RPC

### DIFF
--- a/RpcWallet/RpcWallet.cs
+++ b/RpcWallet/RpcWallet.cs
@@ -309,7 +309,7 @@ namespace Neo.Plugins
             }, from: from, change_address: change_address, fee: fee);
             if (tx.Size > 1024)
             {
-                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
                 tx = Wallet.MakeTransaction(null, new[]
                 {
                     new TransferOutput
@@ -349,7 +349,7 @@ namespace Neo.Plugins
             Transaction tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
             if (tx.Size > 1024)
             {
-                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
                 tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
             }
             if (tx == null)
@@ -377,7 +377,7 @@ namespace Neo.Plugins
             }, change_address: change_address, fee: fee);
             if (tx.Size > 1024)
             {
-                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
                 tx = Wallet.MakeTransaction(null, new[]
                 {
                     new TransferOutput

--- a/RpcWallet/RpcWallet.cs
+++ b/RpcWallet/RpcWallet.cs
@@ -1,4 +1,4 @@
-﻿using Akka.Actor;
+using Akka.Actor;
 using Microsoft.AspNetCore.Http;
 using Neo.IO;
 using Neo.IO.Json;
@@ -307,6 +307,19 @@ namespace Neo.Plugins
                     ScriptHash = to
                 }
             }, from: from, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                tx = Wallet.MakeTransaction(null, new[]
+                {
+                    new TransferOutput
+                        {
+                            AssetId = assetId,
+                            Value = amount,
+                            ScriptHash = to
+                        }
+                }, from: from, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);
@@ -334,6 +347,11 @@ namespace Neo.Plugins
             if (fee < Fixed8.Zero)
                 throw new RpcException(-32602, "Invalid params");
             Transaction tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);
@@ -357,6 +375,19 @@ namespace Neo.Plugins
                     ScriptHash = scriptHash
                 }
             }, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m);
+                tx = Wallet.MakeTransaction(null, new[]
+                {
+                    new TransferOutput
+                    {
+                        AssetId = assetId,
+                        Value = amount,
+                        ScriptHash = scriptHash
+                    }
+                }, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);


### PR DESCRIPTION
Sync to SimplePolicy. But since the input UTXOs are unknown, the extra gas might make the transaction size bigger again. The subtraction of 1024 is not been added for some headroom.