### PR TITLE
RpcNep5Tracker: Handle NEP5 transfers to/from null & limit max results

### DIFF
--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -32,6 +32,7 @@ namespace Neo.Plugins
         private bool _shouldTrackHistory;
         private bool _recordNullAddressHistory;
         private uint _maxResults;
+        private bool _shouldTrackNonStandardMintTokensEvent;
         private Neo.IO.Data.LevelDB.Snapshot _levelDbSnapshot;
 
         public override void Configure()
@@ -44,6 +45,7 @@ namespace Neo.Plugins
             _shouldTrackHistory = (GetConfiguration().GetSection("TrackHistory").Value ?? true.ToString()) != false.ToString();
             _recordNullAddressHistory = (GetConfiguration().GetSection("RecordNullAddressHistory").Value ?? false.ToString()) != false.ToString();
             _maxResults = uint.Parse(GetConfiguration().GetSection("MaxResults").Value ?? "1000");
+            _shouldTrackNonStandardMintTokensEvent = (GetConfiguration().GetSection("TrackNonStandardMintTokens").Value ?? false.ToString()) != false.ToString();
         }
 
         private void ResetBatch()
@@ -102,7 +104,7 @@ namespace Neo.Plugins
             if (!(stateItems[0] is VM.Types.ByteArray)) return;
             var eventName = Encoding.UTF8.GetString(stateItems[0].GetByteArray());
 
-            if (eventName == "mintTokens")
+            if (_shouldTrackNonStandardMintTokensEvent && eventName == "mintTokens")
             {
                 if (stateItems.Count < 4) return;
                 // This is not an official standard but at least one token uses it, and so it is needed for proper

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -60,7 +60,7 @@ namespace Neo.Plugins
 
         private void RecordTransferHistory(Snapshot snapshot, UInt160 scriptHash, UInt160 from, UInt160 to, BigInteger amount, UInt256 txHash, ref ushort transferIndex)
         {
-
+            if (!_shouldTrackHistory) return;
             _transfersSent.Add(new Nep5TransferKey(from,
                     snapshot.GetHeader(snapshot.Height).Timestamp, scriptHash, transferIndex),
                 new Nep5Transfer
@@ -137,8 +137,6 @@ namespace Neo.Plugins
                 var toKey = new Nep5BalanceKey(to, scriptHash);
                 if (!nep5BalancesChanged.ContainsKey(toKey)) nep5BalancesChanged.Add(toKey, new Nep5Balance());
             }
-
-            if (!_shouldTrackHistory) return;
             RecordTransferHistory(snapshot, scriptHash, from, to, amountItem.GetBigInteger(), transaction.Hash, ref transferIndex);
         }
 

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -97,12 +97,14 @@ namespace Neo.Plugins
             VM.Types.Array stateItems,
             Dictionary<Nep5BalanceKey, Nep5Balance> nep5BalancesChanged, ref ushort transferIndex)
         {
+            if (stateItems.Count == 0) return;
             // Event name should be encoded as a byte array.
             if (!(stateItems[0] is VM.Types.ByteArray)) return;
             var eventName = Encoding.UTF8.GetString(stateItems[0].GetByteArray());
 
             if (eventName == "mintTokens")
             {
+                if (stateItems.Count < 4) return;
                 // This is not an official standard but at least one token uses it, and so it is needed for proper
                 // balance tracking to support all tokens in use.
                 if (!(stateItems[2] is VM.Types.ByteArray))
@@ -121,6 +123,7 @@ namespace Neo.Plugins
                 return;
             }
             if (eventName != "transfer") return;
+            if (stateItems.Count < 4) return;
 
             if (!(stateItems[1] is null) && !(stateItems[1] is VM.Types.ByteArray))
                 return;

--- a/RpcNep5Tracker/RpcNep5Tracker.cs
+++ b/RpcNep5Tracker/RpcNep5Tracker.cs
@@ -69,25 +69,32 @@ namespace Neo.Plugins
             // Only care about transfers
             if (eventName != "transfer") return;
 
-            if (!(stateItems[1] is VM.Types.ByteArray))
+            if (!(stateItems[1] is null) && !(stateItems[1] is VM.Types.ByteArray))
                 return;
-            if (!(stateItems[2] is VM.Types.ByteArray))
+            if (!(stateItems[2] is null) && !(stateItems[2] is VM.Types.ByteArray))
                 return;
             var amountItem = stateItems[3];
             if (!(amountItem is VM.Types.ByteArray || amountItem is VM.Types.Integer))
                 return;
-            byte[] fromBytes = stateItems[1].GetByteArray();
-            if (fromBytes.Length != 20) fromBytes = null;
-            byte[] toBytes = stateItems[2].GetByteArray();
-            if (toBytes.Length != 20) toBytes = null;
+            byte[] fromBytes = stateItems[1]?.GetByteArray();
+            if (fromBytes?.Length != 20) fromBytes = null;
+            byte[] toBytes = stateItems[2]?.GetByteArray();
+            if (toBytes?.Length != 20) toBytes = null;
             if (fromBytes == null && toBytes == null) return;
             var from = new UInt160(fromBytes);
             var to = new UInt160(toBytes);
 
-            var fromKey = new Nep5BalanceKey(from, scriptHash);
-            if (!nep5BalancesChanged.ContainsKey(fromKey)) nep5BalancesChanged.Add(fromKey, new Nep5Balance());
-            var toKey = new Nep5BalanceKey(to, scriptHash);
-            if (!nep5BalancesChanged.ContainsKey(toKey)) nep5BalancesChanged.Add(toKey, new Nep5Balance());
+            if (fromBytes != null)
+            {
+                var fromKey = new Nep5BalanceKey(from, scriptHash);
+                if (!nep5BalancesChanged.ContainsKey(fromKey)) nep5BalancesChanged.Add(fromKey, new Nep5Balance());
+            }
+
+            if (toBytes != null)
+            {
+                var toKey = new Nep5BalanceKey(to, scriptHash);
+                if (!nep5BalancesChanged.ContainsKey(toKey)) nep5BalancesChanged.Add(toKey, new Nep5Balance());
+            }
 
             if (!_shouldTrackHistory) return;
             BigInteger amount = amountItem.GetBigInteger();

--- a/RpcNep5Tracker/RpcNep5Tracker/config.json
+++ b/RpcNep5Tracker/RpcNep5Tracker/config.json
@@ -1,6 +1,7 @@
 ﻿{
   "PluginConfiguration": {
     "DBPath": "Nep5BalanceData",
-    "TrackHistory" : true
+    "TrackHistory" : true,
+    "MaxResults" : 1000
   }
 }

--- a/RpcNep5Tracker/RpcNep5Tracker/config.json
+++ b/RpcNep5Tracker/RpcNep5Tracker/config.json
@@ -2,6 +2,7 @@
   "PluginConfiguration": {
     "DBPath": "Nep5BalanceData",
     "TrackHistory" : true,
+    "RecordNullAddressHistory": false,
     "MaxResults" : 1000
   }
 }


### PR DESCRIPTION
Minted NEP5 tokens are sometimes sent from null. Also some contracts destroy tokens sending to null. These changes should handle tracking their balances.

This adds support to the RpcNep5Tracker plugin for: https://github.com/neo-project/proposals/pull/44

Also, while not a standard, at least one popular NEP5 token used a `mintTokens` event to track minting of its tokens. This adds support for it in order to track balances of the known currently in use NEP5 tokens.

Warning: *Currently this code needs testing*