### PR TITLE
a fix suggest about extra charge for transactions over 1024 bytes

### DIFF
--- a/RpcWallet/RpcWallet.cs
+++ b/RpcWallet/RpcWallet.cs
@@ -1,4 +1,4 @@
-﻿using Akka.Actor;
+using Akka.Actor;
 using Microsoft.AspNetCore.Http;
 using Neo.IO;
 using Neo.IO.Json;
@@ -307,6 +307,19 @@ namespace Neo.Plugins
                     ScriptHash = to
                 }
             }, from: from, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
+                tx = Wallet.MakeTransaction(null, new[]
+                {
+                    new TransferOutput
+                        {
+                            AssetId = assetId,
+                            Value = amount,
+                            ScriptHash = to
+                        }
+                }, from: from, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);
@@ -334,6 +347,11 @@ namespace Neo.Plugins
             if (fee < Fixed8.Zero)
                 throw new RpcException(-32602, "Invalid params");
             Transaction tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
+                tx = Wallet.MakeTransaction(null, outputs, from: from, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);
@@ -357,6 +375,19 @@ namespace Neo.Plugins
                     ScriptHash = scriptHash
                 }
             }, change_address: change_address, fee: fee);
+            if (tx.Size > 1024)
+            {
+                fee += Fixed8.FromDecimal(tx.Size * 0.00001m + 0.001m);
+                tx = Wallet.MakeTransaction(null, new[]
+                {
+                    new TransferOutput
+                    {
+                        AssetId = assetId,
+                        Value = amount,
+                        ScriptHash = scriptHash
+                    }
+                }, change_address: change_address, fee: fee);
+            }
             if (tx == null)
                 throw new RpcException(-300, "Insufficient funds");
             return SignAndRelay(tx);

--- a/SimplePolicy/SimplePolicyPlugin.cs
+++ b/SimplePolicy/SimplePolicyPlugin.cs
@@ -103,10 +103,16 @@ namespace Neo.Plugins
             // Not Allow free TX bigger than MaxFreeTransactionSize
             if (tx.IsLowPriority && tx.Size > Settings.Default.MaxFreeTransactionSize) return false;
 
-            // Require proportional fee for TX bigger than MaxFreeTransactionSize
-            if (tx.Size > Settings.Default.MaxFreeTransactionSize)
+            var paysize = tx.Size;
+            foreach(var input in tx.Inputs)
             {
-                Fixed8 fee = Settings.Default.FeePerExtraByte * (tx.Size - Settings.Default.MaxFreeTransactionSize);
+                paysize -= input.Size;
+            }
+
+            // Require proportional fee for TX bigger than MaxFreeTransactionSize
+            if (paysize > Settings.Default.MaxFreeTransactionSize)
+            {
+                Fixed8 fee = Settings.Default.FeePerExtraByte * (paysize - Settings.Default.MaxFreeTransactionSize);
 
                 if (tx.NetworkFee < fee) return false;
             }


### PR DESCRIPTION
#neo-project/neo-cli#303


因为支付是按照交易容量计算 tx.size, 这会造成一个问题，难于处理交易的手续费

当写好了一个交易，增加手续费的输入输出时，这个动作本身就会导致txsize 变化。
而且每一个 txinput 会需要大概0.0034gas的手续费，如果一个txinput 小于这个数字，会陷入死循环

故而提出意见 txinput 不计入收费容量，可解决这个问题。
而且使用大量的txinput 构造交易，也没有很强的可攻击性。