### PR TITLE
Draft for ConsensusPlayground Plugin (P2PLossyConsensus)

### DIFF
--- a/ConsensusPlayground/ConsensusPlayground.cs
+++ b/ConsensusPlayground/ConsensusPlayground.cs
@@ -1,0 +1,43 @@
+﻿using Neo.Network.P2P.Payloads;
+using Neo.Consensus;
+using Neo.Network.P2P;
+using System;
+
+
+namespace Neo.Plugins
+{
+    public class ConsensusPlayground : Plugin, IP2PPlugin
+    {
+        private static Random RandomGnrt = new Random();
+
+        public override void Configure()
+        {
+            Settings.Load(GetConfiguration());
+        }
+
+        public bool OnP2PMessage(Message message)
+        {
+            return true;
+        }
+
+        public bool OnConsensusMessage(ConsensusPayload payload)
+        {
+            if (payload.ConsensusMessage.Type == ConsensusMessageType.PrepareRequest)
+                return (RandomGnrt.NextDouble() > Settings.Default.ProbRejectPrepRequest);
+
+            if (payload.ConsensusMessage.Type == ConsensusMessageType.PrepareResponse)
+                return (RandomGnrt.NextDouble() > Settings.Default.ProbRejectPrepResponse);
+            
+            if (payload.ConsensusMessage.Type == ConsensusMessageType.Commit)
+                return (RandomGnrt.NextDouble() > Settings.Default.ProbRejectCommit);
+
+            if (payload.ConsensusMessage.Type == ConsensusMessageType.ChangeView)
+                return (RandomGnrt.NextDouble() > Settings.Default.ProbRejectChangeView);
+
+            if (payload.ConsensusMessage.Type == ConsensusMessageType.RecoveryMessage)
+                return (RandomGnrt.NextDouble() > Settings.Default.ProbRejectRecover);
+
+            return true;
+        }   
+    }
+}

--- a/ConsensusPlayground/ConsensusPlayground.csproj
+++ b/ConsensusPlayground/ConsensusPlayground.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Version>2.10.1</Version>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Neo.Plugins</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Neo" Version="2.10.1" />
+  </ItemGroup>
+
+</Project>

--- a/ConsensusPlayground/ConsensusPlayground.sln
+++ b/ConsensusPlayground/ConsensusPlayground.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2017
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsensusPlayground", "ConsensusPlayground.csproj", "{FDCCABDE-D14C-43CD-8DA8-7F63EF2CB920}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDCCABDE-D14C-43CD-8DA8-7F63EF2CB920}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDCCABDE-D14C-43CD-8DA8-7F63EF2CB920}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDCCABDE-D14C-43CD-8DA8-7F63EF2CB920}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDCCABDE-D14C-43CD-8DA8-7F63EF2CB920}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/ConsensusPlayground/ConsensusPlayground/config.json
+++ b/ConsensusPlayground/ConsensusPlayground/config.json
@@ -3,7 +3,7 @@
     "ProbRejectPrepRequest": 0.25,
     "ProbRejectPrepResponse": 0.5,
     "ProbRejectCommit": 0.5,
-    "ProbRejectChangeView": 0
+    "ProbRejectChangeView": 0,
     "ProbRejectRecover": 0
   }
 }

--- a/ConsensusPlayground/ConsensusPlayground/config.json
+++ b/ConsensusPlayground/ConsensusPlayground/config.json
@@ -1,0 +1,9 @@
+﻿{
+  "PluginConfiguration": {
+    "ProbRejectPrepRequest": 0.25,
+    "ProbRejectPrepResponse": 0.5,
+    "ProbRejectCommit": 0.5,
+    "ProbRejectChangeView": 0
+    "ProbRejectRecover": 0
+  }
+}

--- a/ConsensusPlayground/Settings.cs
+++ b/ConsensusPlayground/Settings.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Neo.Plugins
+{
+    internal class Settings
+    {
+        /// <summary>
+        /// Probability of rejecting consensus messages - by type
+        /// </summary>
+        public double ProbRejectPrepRequest { get; }
+        public double ProbRejectPrepResponse { get; }
+        public double ProbRejectCommit { get; }
+        public double ProbRejectChangeView { get; }
+        public double ProbRejectRecover { get; }
+
+        public static Settings Default { get; private set; }
+
+        private Settings(IConfigurationSection section)
+        {
+            this.ProbRejectPrepRequest = GetValueOrDefault(section.GetSection("ProbRejectPrepRequest"), 0.25, p => double.Parse(p));
+            this.ProbRejectPrepResponse = GetValueOrDefault(section.GetSection("ProbRejectPrepResponse"), 0.5, p => double.Parse(p));
+            this.ProbRejectCommit = GetValueOrDefault(section.GetSection("ProbRejectCommit"), 0.5, p => double.Parse(p));
+            this.ProbRejectChangeView = GetValueOrDefault(section.GetSection("ProbRejectChangeView"), 0, p => double.Parse(p));
+            this.ProbRejectRecover = GetValueOrDefault(section.GetSection("ProbRejectRecover"), 0, p => double.Parse(p));
+        }
+
+        public T GetValueOrDefault<T>(IConfigurationSection section, T defaultValue, Func<string, T> selector)
+        {
+            if (section.Value == null) return defaultValue;
+            return selector(section.Value);
+        }
+
+        public static void Load(IConfigurationSection section)
+        {
+            Default = new Settings(section);
+        }
+    }
+}


### PR DESCRIPTION
A plugin similar to this has been used during the tests for dBFT 2.0, designed by @shargon P2PPlugin and @jsolman.
This is a more configurable version.

Maybe it could be considered to be included here.
I think that NGD and other communities may use this for analyzing consensus and generating different kinds of reports.