### PR TITLE
Using project references

### DIFF
--- a/ApplicationLogs/ApplicationLogs.csproj
+++ b/ApplicationLogs/ApplicationLogs.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00044" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
-
 </Project>

--- a/CoreMetrics/CoreMetrics.csproj
+++ b/CoreMetrics/CoreMetrics.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00122" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
-
 </Project>

--- a/ImportBlocks/ImportBlocks.csproj
+++ b/ImportBlocks/ImportBlocks.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00044" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
-
 </Project>

--- a/RpcNep5Tracker/RpcNep5Tracker.csproj
+++ b/RpcNep5Tracker/RpcNep5Tracker.csproj
@@ -12,6 +12,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00122" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
 </Project>

--- a/RpcSecurity/RpcSecurity.csproj
+++ b/RpcSecurity/RpcSecurity.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00044" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
-
 </Project>

--- a/StatesDumper/StatesDumper.csproj
+++ b/StatesDumper/StatesDumper.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo" Version="3.0.0-CI00044" />
+    <ProjectReference Include="..\..\neo\neo.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Referencing neo-project instead of nuget. Used for 'debugging'.